### PR TITLE
Scope package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "styled-elements",
+  "name": "@lewisvrobinson/styled-elements",
   "version": "1.0.0",
   "description": "",
   "files": [


### PR DESCRIPTION
Scope the package to the @lewisvrobinson org to avoid name conflicts with the other, very similar, slightly more sophisticated package of the same name.